### PR TITLE
Keep query message if end of servers is reached.

### DIFF
--- a/domain-resolv/src/stub/resolver.rs
+++ b/domain-resolv/src/stub/resolver.rs
@@ -211,24 +211,24 @@ impl Query {
     /// Starts a new query for the current server.
     ///
     /// Prepares the query message and then starts the server query. Returns
-    /// `None` if a query cannot be started because 
+    /// `None` if a query cannot be started because there are no more servers
+    /// left.
     fn start_query(&mut self) -> Option<ServerQuery> {
-        if self.message.is_none() {
-            return None;
-        }
-        let mut message = self.message.take().unwrap().unfreeze();
+        let message = self.message.take().unwrap();
         let (message, res) = {
-            let info = match self.current_server() {
-                Some(info) => info,
-                None => return None
-            };
-            info.prepare_message(&mut message);
-            let message = message.freeze();
-            let res = ServerQuery::new(message.clone(), info);
-            (message, res)
+            match self.current_server() {
+                Some(info) => {
+                    let mut message = message.unfreeze();
+                    info.prepare_message(&mut message);
+                    let message = message.freeze();
+                    let res = ServerQuery::new(message.clone(), info);
+                    (message, Some(res))
+                }
+                None => (message, None)
+            }
         };
         self.message = Some(message);
-        Some(res)
+        res
     }
 
     /// Returns the info for the current server.


### PR DESCRIPTION
Thank you for your pull request!

The reason for the occasional panics was that when we reached the end of the server list, we didn’t put the message back into the query. I have adjusted your PR to do that instead, so that we can continue with the next round of servers.

In order to keep you credited, I decided to create a PR to your branch.